### PR TITLE
Iron-Warriors Panoptica 5.3 Done.

### DIFF
--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -2413,7 +2413,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Melee, Brutal (3), Sunder, Immaterial Blades (AP1), Lance,Exoshock (5+)" field="2f86-c8b4-b3b4-3ff9"/>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -3710,7 +3710,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Ordnance 1, Blast (3&quot;), Sunder, Rending (5+), Brutal (3), Wrecker" field="2f86-c8b4-b3b4-3ff9"/>
@@ -3749,7 +3749,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Ordnance 1, Barrage, Large Blast (5&quot;), Pinning, Rending (5+)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -3784,7 +3784,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Ordnance 1, Large Blast (5&quot;), Sunder, Rending (4+), Brutal (4),Wrecker" field="2f86-c8b4-b3b4-3ff9"/>
@@ -4328,7 +4328,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Heavy 1, Large Blast (5&quot;), †Graviton Collapse, Torsion Crusher,Ignores Cover, Concussive (1), Haywire" field="2f86-c8b4-b3b4-3ff9"/>
@@ -5099,7 +5099,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Heavy 3, Pinning, Guided Fire, Auto-Servo Tracking" field="2f86-c8b4-b3b4-3ff9"/>
@@ -5612,7 +5612,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Heavy 8, Deflagrate, Pinning" field="2f86-c8b4-b3b4-3ff9"/>
@@ -5640,7 +5640,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Ordnance 1, Heavy Beam, Deflagrate, Rending (5+), Pinning,Wrecker" field="2f86-c8b4-b3b4-3ff9"/>
@@ -6698,7 +6698,7 @@ Additionally, a machinator array incorporates a flamer and a meltagun. A model w
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Melee, Brutal (2)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -6891,7 +6891,7 @@ Additionally, a machinator array incorporates a flamer and a meltagun. A model w
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Melee, Shred, Two-Handed, Rupture (6+)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -7465,7 +7465,7 @@ Four single Blast Shields</characteristic>
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Ordnance 1, Massive Blast (7&quot;), Rending (5+), Limited Ammunition,Pinning, Shell Shock (1)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -7921,7 +7921,7 @@ A unit that makes a Shooting Attack as part of a Scornful Fire Reaction may not 
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Destroyer 1, Apocalyptic Blast (10&quot;), Ignores Cover" field="2f86-c8b4-b3b4-3ff9"/>
@@ -8077,7 +8077,7 @@ A unit that makes a Shooting Attack as part of a Scornful Fire Reaction may not 
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="12" field="24d9-b8e1-a355-2458"/>
@@ -8233,7 +8233,7 @@ A. No.</description>
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Ordnance 1, Massive Blast (7&quot;), Rending (4+), Reactor Overload,Plasma Burn" field="2f86-c8b4-b3b4-3ff9"/>
@@ -8268,7 +8268,7 @@ A. No.</description>
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="3" field="f7a6-e0d8-7973-cd8d"/>
@@ -8300,7 +8300,7 @@ A. No.</description>
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Melee, Brutal (2)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -8524,7 +8524,7 @@ A. No.</description>
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Ordnance 1, Barrage, Large Blast (5&quot;), Pinning, Rending (5+),Brutal (2)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -10461,7 +10461,7 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="-" field="95ba-cda7-b831-6066"/>
@@ -10559,7 +10559,7 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Heavy 1, Blast (3&quot;), Barrage, Pinning, Rupture (5+)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -10774,7 +10774,7 @@ Hull Mounted (Rear) Mounted Twin-linked Heavy Bolter or Heavy Flamers</character
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="1" field="f7a6-e0d8-7973-cd8d"/>
@@ -11138,7 +11138,7 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="36&quot;" field="95ba-cda7-b831-6066"/>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="43" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2ee4-57ed-db44-8a63" name="LA -   IV: Iron Warriors" revision="44" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="67" type="catalogue">
   <entryLinks>
     <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>
@@ -3115,11 +3115,47 @@
                 <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
                 <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
               </characteristics>
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden" join=""/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
             </profile>
             <profile id="c102-01fc-2186-f473" name="The Logos" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
                 <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Logos provides a 2+ Armour Save and a 3+ Invulnerable Save, and allows Perturabo to ignore all the effects of Night Fighting, and when Perturabo or any unit he has joined makes the Interceptor Advanced Reaction, the Reaction does not cost the controlling player a point from their Reaction Allotment. This does not allow the unit to make more than one Reaction per Phase, but does allow the controlling player to exceed the normal three Reactions limit in a given turn.</characteristic>
               </characteristics>
+            </profile>
+            <profile id="746b-9026-8443-a0fd" name="Perturabo" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique, Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">7</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">6</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">6</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden" join=""/>
+                    <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
             </profile>
           </profiles>
           <infoLinks>
@@ -3189,6 +3225,40 @@
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5382-32c3-faf7-929b" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink id="a5de-da37-b287-f666" name="Cognis-Signum" hidden="false" collective="false" import="true" targetId="93b3-2d66-f7a3-be42" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd84-00ad-84e4-3ee3" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e5c-c639-d271-1b8a" type="max"/>
+              </constraints>
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden" join=""/>
+                    <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
+            </entryLink>
+            <entryLink id="02fc-f14b-53e5-fc16" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d66d-a61a-ce50-c1f5" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08ef-225a-3f81-7a5c" type="max"/>
+              </constraints>
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden" join=""/>
+                    <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -3248,6 +3318,19 @@
           <characteristics>
             <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Shooting Attacks made using a weapon with the Heavy type by a model with a Ferrum Occularis gain the Precision Shots (6+) special rule, as long as the attack is not made as part of a Reaction or a Snap Shot.</characteristic>
           </characteristics>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="Shooting Attacks made using a weapon with the Heavy type by a
+model with a Ferrum Occularis gain the Sunder Special Rule, as long as
+the attack is not made as part of a Reaction or a Snap Shot." field="347e-ee4a-764f-6be3" join=""/>
+                <modifier type="set" value="Pano 5.3 pg 95" field="annotation"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </profile>
       </profiles>
       <infoLinks>
@@ -3256,6 +3339,28 @@
           <modifiers>
             <modifier type="set" field="name" value="Precision Shots (6+)"/>
           </modifiers>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
+        </infoLink>
+        <infoLink id="50b5-fc2b-0d49-14ba" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule">
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </infoLink>
       </infoLinks>
       <categoryLinks>
@@ -3880,6 +3985,17 @@
                   <characteristics>
                     <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit that includes at least one model with an omni-scope ignores all the effects of Night Fighting, and when a unit that includes one or more models with this special rule makes the Interceptor Advanced Reaction, the reaction does not cost the controlling player a point from their Reaction Allotment. This does not allow the unit to make more than one Reaction per Phase, but does allow the controlling player to exceed the normal three Reactions limit in a given Phase.</characteristic>
                   </characteristics>
+                  <modifierGroups>
+                    <modifierGroup type="and">
+                      <modifiers>
+                        <modifier type="set" value=" A unit that includes at least one model with an Omni-Scope has the Night Vision Special Rule. In addition, when a unit that includes one or more models equipped with an Omni-Scope makes the Interceptor Advanced Reaction , the reaction does not cost the Controlling Player a point from their Reaction Allotment . This does not allow the unit to make more than one Reaction per Phase, but does allow the Controlling Player to exceed the normal three Reactions limit in a given Phase." field="347e-ee4a-764f-6be3" join=""/>
+                        <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+                      </modifiers>
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifierGroup>
+                  </modifierGroups>
                 </profile>
                 <profile id="ad40-f3a3-dfb2-f9c1" name="Siege Master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
                   <characteristics>
@@ -4048,6 +4164,40 @@
             <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">24</characteristic>
             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One at the rear.</characteristic>
           </characteristics>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
+        </profile>
+        <profile id="4d9a-38e3-252b-3bd5" name="The Tormentor" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport, Unique)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">5</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">24</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One at the rear.</characteristic>
+          </characteristics>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden" join=""/>
+                <modifier type="set" value="Pano 5.3 pg 95" field="annotation"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </profile>
       </profiles>
       <rules>
@@ -4106,6 +4256,16 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </selectionEntry>
         <selectionEntry id="72cf-b3cd-47b6-ff35" name="Hull (Front) Mounted twin-linked heavy bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -4123,6 +4283,16 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </selectionEntry>
         <selectionEntry id="5463-1794-887b-ba25" name="Hull (Right) Mounted lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -4140,6 +4310,16 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </selectionEntry>
         <selectionEntry id="e094-dc48-76e3-8394" name="Hull (Left) Mounted lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -4157,6 +4337,16 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </selectionEntry>
         <selectionEntry id="7b49-6469-2d4b-fc35" name="Hull (Left) Mounted twin-linked heavy bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -4174,6 +4364,156 @@
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
           </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="true" field="hidden" join=""/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
+        </selectionEntry>
+        <selectionEntry id="9d82-28be-e09f-bcd9" name="Sponson (Right) Mounted lascannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa5-63bf-4285-6002" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a2f-1659-3ab7-19ca" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d5d2-3ca9-9d71-5972" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c88-80af-26c6-8175" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af71-5e6f-bb85-97a5" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+          </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden" join=""/>
+                <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
+        </selectionEntry>
+        <selectionEntry id="940a-a857-2185-e9e3" name="Sponson (Left) Mounted lascannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9329-4aaf-9a38-77d6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f6c-8e3e-4f44-73cf" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5f86-b8bd-7829-bb46" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f75a-c563-9a20-9372" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="500c-e026-7249-5629" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+          </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden" join=""/>
+                <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
+        </selectionEntry>
+        <selectionEntry id="b031-1a66-0de1-f409" name="Sponson (Left) Mounted Twin-Linked Shrapnel Cannons" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b9-d68b-2ec2-ce42" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3f5-2338-1258-f975" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5351-ee1a-ca39-ad38" name="Gravis Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="ce7e-4548-10b5-8762" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="336f-cc51-0a57-58be" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee87-602a-8bf6-bd73" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+          </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden" join=""/>
+                <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
+        </selectionEntry>
+        <selectionEntry id="6409-8857-3f43-4c56" name="Sponson (Right) Mounted Twin-Linked Shrapnel Cannons" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6942-6f1b-6156-5dae" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c5e-492c-cf32-212b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7a61-5a78-a2fb-5f49" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bd2-8798-c61d-5868" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0e1-0376-19b9-d950" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+          </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden" join=""/>
+                <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
+        </selectionEntry>
+        <selectionEntry id="b7a1-2610-7373-d36b" name="Hull (Front) Mounted Twin-Linked Shrapnel Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7b5-757d-00c5-19c5" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4d2-b034-9c48-d6f0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5ef0-e64a-f7f8-91b3" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3459-aa8e-f7b5-9621" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="171c-8e8a-4e97-b8cd" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+          </costs>
+          <modifierGroups>
+            <modifierGroup type="and">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden" join=""/>
+                <modifier type="set" value="Pano 5.3 pg 88" field="annotation"/>
+              </modifiers>
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifierGroup>
+          </modifierGroups>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -4193,6 +4533,17 @@
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="800"/>
       </costs>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="set" value="750" field="costs" join=""/>
+            <modifier type="set" value="Pano 5.3 pg 95" field="annotation"/>
+          </modifiers>
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
     </selectionEntry>
     <selectionEntry id="35e0-3b3a-f569-3da8" name="Kyr Vhalen" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -4381,6 +4732,7 @@
           </modifiers>
         </infoLink>
         <infoLink id="311f-2a92-88cf-ea1f" name="Legiones Astartes (Iron Warriors)" hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
+        <infoLink id="46d2-6fd1-5f36-3cc6" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1e3b-3776-e033-cd91" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -4624,6 +4976,17 @@
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="542b-ded9-42e1-acc6" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="d236-0afb-455c-8e7d" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="45" field="d2ee-04cb-5f8a-2642" join=""/>
+                    <modifier type="set" value="Pano 5.3 pg 117" field="annotation"/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
             </selectionEntry>
             <selectionEntry id="4794-a3ce-730c-4c66" name="Dominator w/Heavy Weapon" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -4681,6 +5044,17 @@
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="1dfb-1c6d-41d4-beb4" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="0e6c-03f5-4911-8c8c" name="Heavy Sub-type" primary="false"/>
               </categoryLinks>
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="45" field="d2ee-04cb-5f8a-2642" join=""/>
+                    <modifier type="set" value="Pano 5.3 pg 117" field="annotation"/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4738,6 +5112,19 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="114a-c21e-1bd1-d95d" type="max"/>
               </constraints>
+            </entryLink>
+            <entryLink id="b1d0-5ee9-d29a-25eb" name="Land Raider Spartan" hidden="true" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
+              <modifierGroups>
+                <modifierGroup type="and">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden" join=""/>
+                    <modifier type="set" value="Pano 5.3 pg 117" field="annotation"/>
+                  </modifiers>
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifierGroup>
+              </modifierGroups>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -2756,7 +2756,7 @@
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="4" field="f7a6-e0d8-7973-cd8d"/>
@@ -3077,7 +3077,7 @@
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="24&quot;" field="95ba-cda7-b831-6066"/>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -956,7 +956,7 @@ Additional rules are given to units based on Legion and Unit.</description>
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="x2" field="24d9-b8e1-a355-2458"/>
@@ -2263,7 +2263,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Melee, Two-Handed, Shred, Murderous Strike (5+), Unwieldy,Breaching (5+)" field="2f86-c8b4-b3b4-3ff9"/>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -191,7 +191,7 @@ When deployed onto the battlefield (either at the start of the battle or when ar
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Melee, Shred, Sunder, Brutal (3)" field="2f86-c8b4-b3b4-3ff9"/>
@@ -6220,7 +6220,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="1" field="f7a6-e0d8-7973-cd8d"/>
@@ -6867,7 +6867,7 @@ A unit composed entirely of models with Utan jump boosters may not Run. During R
           <modifierGroups>
             <modifierGroup type="and">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="True" includeChildSelections="True"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="1231-877a-96d9-cacd" shared="true" includeChildSelections="true"/>
               </conditions>
               <modifiers>
                 <modifier type="set" value="Heavy 8, Deflagrate" field="2f86-c8b4-b3b4-3ff9"/>


### PR DESCRIPTION
All the Change for Iron Warriors in Panoptica 5.3. Not anything from Centura

Please set a title for the PR describing your changes,
fill out the information below, and delete this heading.

## Added Units
None

## Fixed Units
Dominator Cohort
Erasmus Golg
Iron Havocs
Perturabo
The Tormentor
Tyrant Siege Terminator

### Related Issues
None

## Not done yet

_Any issues related to your new changes, or known missing options_

## Test Case

Please upload a roster do demonstrate your changes. 
